### PR TITLE
Update to use new base images for Grails 5.3.2

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2020 University of Oxford
+Copyright 2020-2023 University of Oxford and NHS England
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
     postgres:
-        image: "maurodatamapper/postgres:12.0-alpine"
+        image: "maurodatamapper/postgres:12.14-alpine"
         build: ./postgres
         shm_size: 512mb
         environment:

--- a/mauro-data-mapper/Dockerfile
+++ b/mauro-data-mapper/Dockerfile
@@ -1,6 +1,6 @@
 
-ARG MDM_BASE_IMAGE_VERSION=grails-5.1.9-jdk17.0.3_7-node-14.18.1-npm-8.3.0.R2
-ARG TOMCAT_IMAGE_VERSION=9.0.65-jre17-temurin
+ARG MDM_BASE_IMAGE_VERSION=grails-5.3.2-jdk17.0.6_10-node-16.10.0-npm-8.3.0
+ARG TOMCAT_IMAGE_VERSION=9.0.71-jre17-temurin
 
 FROM maurodatamapper/mdm_base:$MDM_BASE_IMAGE_VERSION AS mdm-build
 LABEL org.opencontainers.image.authors="Oliver Freeman <oliver.freeman@bdi.ox.ac.uk>, Joe Crawford <joseph.crawford@bdi.ox.ac.uk>"

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12.10-alpine
+FROM postgres:12.14-alpine
 COPY fixtures /docker-entrypoint-initdb.d
 
 ENV POSTGRES_PASSWORD=postgresisawesome \


### PR DESCRIPTION
Update dependencies to for Grails 5.3.2

- Once the release is finished, the updated base images should be published to Docker Hub