### PR TITLE
feature/add nhsd datadictionary orchestrator

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
     postgres:
         image: "maurodatamapper/postgres:12.14-alpine"
@@ -16,10 +15,11 @@ services:
             args:
                 MDM_APPLICATION_COMMIT: "${MDM_APPLICATION_COMMIT}"
                 MDM_UI_COMMIT: "${MDM_UI_COMMIT}"
-                ADDITIONAL_PLUGINS: ""
-                MDM_UI_THEME_NAME: "default"
+                ADDITIONAL_PLUGINS: "uk.ac.ox.softeng.maurodatamapper.plugins:mdm-plugin-nhs-data-dictionary:2.0.0-SNAPSHOT"
+                MDM_UI_THEME_NAME: "nhs-digital"
                 CACHE_BURST: "${CACHE_BURST}"
                 MDM_EXPLORER_API_ENDPOINT: "http://localhost:${MDM_PORT}/api"
+                NHSD_DD_ORCHESTRATION_API_ENDPOINT: "http://localhost:${NHSD_ORCHESTRATION_PORT}/api"
         environment:
             PGPASSWORD: postgresisawesome
             runtime.config.path: /usr/local/tomcat/conf/runtime.yml

--- a/mauro-data-mapper/Dockerfile
+++ b/mauro-data-mapper/Dockerfile
@@ -8,13 +8,18 @@ LABEL org.opencontainers.image.authors="Oliver Freeman <oliver.freeman@bdi.ox.ac
 ARG MDM_APPLICATION_COMMIT=main
 ARG MDM_UI_COMMIT=main
 ARG ADDITIONAL_PLUGINS=""
-ARG MDM_UI_THEME_NAME="default"
+ARG MDM_UI_THEME_NAME="nhs-digital"
 ARG MDM_UI_FEATURE_SUBSCRIBED_CATALOGUES="true"
 
 ARG DEPLOY_MDM_EXPLORER=0
 ARG MDM_EXPLORER_VERSION="1.0.0-SNAPSHOT"
 ARG MDM_EXPLORER_BUILD_HOME=/opt/mdm-explorer/dist
 ARG MDM_EXPLORER_API_ENDPOINT="http://localhost:${MDM_PORT}/api"
+
+ARG DEPLOY_NHSD_DD_ORCHESTRATION=0
+ARG NHSD_DD_ORCHESTRATION_VERSION="1.0.0-SNAPSHOT"
+ARG NHSD_DD_ORCHESTRATION_BUILD_HOME=/opt/nhsd-datadictionary-orchestration/dist
+ARG NHSD_DD_ORCHESTRATION_API_ENDPOINT="http://localhost:${NHSD_ORCHESTRATION_PORT}/api"
 
 # This is needed to ensure the fetch and checkout are always run
 # If the arg is passed in using a random value then it will invalidate the docker cache and force the following steps to re-run
@@ -28,6 +33,7 @@ ARG CACHE_BURST=1
 RUN cd "$MDM_APPLICATION_HOME" && git fetch && git checkout "$MDM_APPLICATION_COMMIT" && if [[ `git status` != HEAD\ detached* ]]; then git pull; fi
 RUN cd "$MDM_UI_HOME" && git fetch && git checkout "$MDM_UI_COMMIT" && if [[ `git status` != HEAD\ detached* ]]; then git pull; fi
 RUN mkdir -p $MDM_EXPLORER_BUILD_HOME
+RUN mkdir -p $NHSD_DD_ORCHESTRATION_BUILD_HOME
 
 # Copy in the building scripts
 COPY build_scripts /usr/local/bin/
@@ -45,6 +51,7 @@ COPY mdm-ui $MDM_UI_HOME/
 # The front end build will try to use precompiled sources or it will build locally from the given commit/tagU
 RUN build_frontend.sh
 RUN build_explorer.sh
+RUN build_orchestrator.sh
 
 # The only way to include plugins is to build the API manually, however this actually takes very little time as we already have all the
 # dependencies downloaded
@@ -68,3 +75,4 @@ ENV CATALINA_OPTS="-Xmx8g -Xms512m -XX:+UseG1GC -XX:+UseStringDeduplication -XX:
 
 COPY --from=mdm-build ${MDM_BUILD_HOME} ${CATALINA_HOME}/webapps/ROOT
 COPY --from=mdm-build ${MDM_EXPLORER_BUILD_HOME} ${CATALINA_HOME}/webapps/explorer
+COPY --from=mdm-build ${NHSD_DD_ORCHESTRATION_BUILD_HOME} ${CATALINA_HOME}/webapps/orchestration

--- a/mauro-data-mapper/build_scripts/build_orchestrator.sh
+++ b/mauro-data-mapper/build_scripts/build_orchestrator.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+precompiledBuild(){
+  echo 'Using pre-compiled source'
+
+  if [[ $NHSD_DD_ORCHESTRATION_VERSION == *SNAPSHOT ]]
+  then
+    NHSD_DD_ORCHESTRATION_LIBRARY='artifacts-snapshots'
+  else
+    NHSD_DD_ORCHESTRATION_LIBRARY='artifacts'
+  fi
+
+  NHSD_DD_ORCHESTRATION_URL="https://jenkins.cs.ox.ac.uk/artifactory/${NHSD_DD_ORCHESTRATION_LIBRARY}/mauroDataMapper/nhsd-datadictionary-orchestration/nhsd-datadictionary-orchestration-${NHSD_DD_ORCHESTRATION_VERSION}.tgz"
+
+  echo "Downloading precompiled sources ${NHSD_DD_ORCHESTRATION_URL}"
+
+  cd /opt || exit
+  curl -LO "$NHSD_DD_ORCHESTRATION_URL"
+  tar xzf "nhsd-datadictionary-orchestration-${NHSD_DD_ORCHESTRATION_VERSION}.tgz"
+  mkdir "$NHSD_DD_ORCHESTRATION_BUILD_HOME"
+  cp -r "nhsd-datadictionary-orchestration-${NHSD_DD_ORCHESTRATION_VERSION}"/* "$NHSD_DD_ORCHESTRATION_BUILD_HOME"
+
+  find "$NHSD_DD_ORCHESTRATION_BUILD_HOME" -name main.*.js -exec sed -e "s|apiEndpoint:\"api\",|apiEndpoint:\"${NHSD_DD_ORCHESTRATION_API_ENDPOINT}\",|g" -i {} \;
+}
+
+precompiledBuild


### PR DESCRIPTION
Added `./build_scripts/build_orchestrator.sh` based on `build_explorer.sh` with the ARGS changed to those for the orchestrator

Created new ARGS based on the `MDM_EXPLORER` with the prefix `NHSD_DD_ORCHESTRATION`

Added a new `NHSD_ORCHESTRATION_PORT` to use in place of `MDM_PORT` which will need to be set in the environment when the image is built.