### PR TITLE
Point to new base images

### DIFF
--- a/.env
+++ b/.env
@@ -8,11 +8,11 @@
 # 1. a tagged release e.g. 4.10.0
 # 2. a branch e.g. main or develop
 # 3. a git commit hash
-MDM_APPLICATION_COMMIT=5.3.0
-MDM_UI_COMMIT=7.3.0
+MDM_APPLICATION_COMMIT=main
+MDM_UI_COMMIT=main
 
 # Change this to alter the port MDM is published to
 MDM_PORT=8082
 
 # Change this to change the tag assigned to the built docker mdm image
-MDM_TAG=2023.1.1
+MDM_TAG=2023.1.2

--- a/mauro-data-mapper/Dockerfile
+++ b/mauro-data-mapper/Dockerfile
@@ -1,6 +1,6 @@
 
-ARG MDM_BASE_IMAGE_VERSION=grails-5.3.2-jdk17.0.6_10-node-16.10.0-npm-8.3.0-multiarch
-ARG TOMCAT_IMAGE_VERSION=9.0.71-jre17-temurin-multiarch
+ARG MDM_BASE_IMAGE_VERSION=grails-5.3.2-jdk17.0.6_10-node-16.10.0-npm-8.3.0-multiarch.R2
+ARG TOMCAT_IMAGE_VERSION=9.0.71-jre17-temurin-multiarch.R2
 
 FROM maurodatamapper/mdm_base:$MDM_BASE_IMAGE_VERSION AS mdm-build
 LABEL org.opencontainers.image.authors="Oliver Freeman <oliver.freeman@bdi.ox.ac.uk>, Joe Crawford <joseph.crawford@bdi.ox.ac.uk>"

--- a/mauro-data-mapper/build_scripts/build_explorer.sh
+++ b/mauro-data-mapper/build_scripts/build_explorer.sh
@@ -10,7 +10,7 @@ precompiledBuild(){
      MDM_EXPLORER_LIBRARY='artifacts'
    fi
 
-  MDM_EXPLORER_URL="https://jenkins.cs.ox.ac.uk/artifactory/${MDM_EXPLORER_LIBRARY}/mauroDataMapper/mdm-explorer/mdm-explorer-${MDM_EXPLORER_VERSION}.tgz"
+  MDM_EXPLORER_URL="https://mauro-repository.com/${MDM_EXPLORER_LIBRARY}/mauroDataMapper/mdm-explorer/mdm-explorer-${MDM_EXPLORER_VERSION}.tgz"
 
   echo "Downloading precompiled sources ${MDM_EXPLORER_URL}"
 


### PR DESCRIPTION
Update to use new base images with updated `mauro-repository.com` URLs:

* mdm-base: `grails-5.3.2-jdk17.0.6_10-node-16.10.0-npm-8.3.0-multiarch.R2`
* tomcat: `9.0.71-jre17-temurin-multiarch.R2`